### PR TITLE
#95: run command before latexmk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,9 @@ all: test
 
 test:
 	docker build . -t latexmk-action
-	docker run --rm -v "$$(pwd):/w" -e HOME -e INPUT_PACKAGES=xcolor latexmk-action
+	docker run --rm -v "$$(pwd):/w" -e HOME -e INPUT_BEFORE='echo before > before.txt' -e INPUT_PACKAGES=xcolor latexmk-action
+	test "$$(cat before.txt)" = before
 	docker rmi latexmk-action
 
 clean:
-	rm -f *.dvi *.pdf *.fls *.aux *.fdb_latexmk *.log
+	rm -f *.dvi *.pdf *.fls *.aux *.fdb_latexmk *.log before.txt

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ jobs:
           cmd: latexmk
           path: foo
           document: paper.tex
+          before: npm install -g eolang
           opts: -pdf
           packages: acmart tikz
 ```
@@ -34,6 +35,7 @@ The options available (provided via the `with` YAML element):
 * `cmd` is the command to run (default is `latexmk`)
 * `path` is a relative path of the directory with `.tex` file(s)
 * `document` is a name of the `.tex` file to compile (no default)
+* `before` is a command to run before `latexmk` starts
 * `opts` is the options to pass to `latexmk`
 * `packages` is a space-separated list of TeXLive package to install
   from [CTAN](https://ctan.org)

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'The command to run'
     required: false
     default: 'latexmk'
+  before:
+    description: 'Command to run before latexmk starts'
+    required: false
+    default: ''
   opts:
     description: 'Command-line options for latexmk'
     required: false

--- a/entry.sh
+++ b/entry.sh
@@ -44,6 +44,10 @@ ls -al
 
 echo "latexmk-action 0.0.0"
 
+if [ -n "${INPUT_BEFORE}" ]; then
+  eval "${INPUT_BEFORE}"
+fi
+
 read -r -a opts <<< "${INPUT_OPTS}"
 if [ -n "${INPUT_DOCUMENT}" ]; then
   opts+=("${INPUT_DOCUMENT}")


### PR DESCRIPTION
Closes #95.

Changes:
- adds a `before` action input
- runs it after workspace/path setup and immediately before the latexmk command
- documents the option and extends the Docker smoke test with a `before` assertion

Validation:
- `bash -n entry.sh`
- `ruby -e 'require "yaml"; YAML.load_file("action.yml"); Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f) }'`
- `npx --yes markdownlint-cli2 README.md`
- temp-workspace `entry.sh` run with `INPUT_BEFORE='printf before > before.txt'` and `INPUT_CMD=true` verified the file content
- `git diff --check`
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact`

Not run:
- `make test` is blocked locally because `docker` is not installed (`bash: docker: command not found`).
